### PR TITLE
Re-export ErrorInfo type

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -66,7 +66,8 @@ declare namespace React {
 	export import ReactNode = preact.ComponentChild;
 	export import ReactElement = preact.VNode;
 	export import Consumer = preact.Consumer;
-
+	export import ErrorInfo = preact.ErrorInfo;
+	
 	// Suspense
 	export import Suspense = _Suspense.Suspense;
 	export import lazy = _Suspense.lazy;


### PR DESCRIPTION
This type is useful when creating an ErrorBoundary. See #3452